### PR TITLE
fix small edge-case bug when refining wlen solution

### DIFF
--- a/src/excalibuhr/pipeline.py
+++ b/src/excalibuhr/pipeline.py
@@ -1893,7 +1893,7 @@ class CriresPipeline:
         # mask the detector edges 
         Ncut = 10
 
-        for data_type in [data_frame, data_comb]:
+        for j, data_type in enumerate([data_frame, data_comb]):
             for label in data_type:
                 indices = (self.product_info[self.key_caltype] == label)
                 
@@ -1910,12 +1910,13 @@ class CriresPipeline:
 
                     # output filename
                     l = label.split('_')[-1]
-                    if data_type == data_comb:
-                        file_name = os.path.join(self.combpath, 
-                            '_'.join(['SPEC', target.replace(" ", ""), l]))
-                    else:
+                    if j == 0:  # data_frame
                         file_name = os.path.join(self.framepath, 
-                            '_'.join(['SPEC_SERIES', target.replace(" ", ""), l]))
+                                                 '_'.join(['SPEC_SERIES', target.replace(" ", ""), l]))
+                    else:  # data_comb
+                        file_name = os.path.join(self.combpath,
+                            '_'.join(['SPEC', target.replace(" ", ""), l]))
+
                         
                     indices_obj = indices & \
                         (self.product_info[self.key_target_name] == target)
@@ -1962,7 +1963,7 @@ class CriresPipeline:
                                 dt.append(hdu["FLUX"].data)
                                 dt_err.append(hdu["FLUX_ERR"].data)
                         nframe = len(dt)
-                        if data_type == data_comb:
+                        if j == 1:
                             # mean-combine each individual frames
                             dt, dt_err = su.combine_frames(dt, dt_err, collapse='mean')
                             self._plot_spec_by_order(file_name+'_'+item_wlen, dt, wlen)
@@ -1978,7 +1979,7 @@ class CriresPipeline:
                     wlens = wlens[indice_sort]
 
                     
-                    if data_type == data_comb:
+                    if j == 1:  # data_comb
                         # reshape spectra in 2D shape: (N_chips, N_pixel)
                         spec_series = np.reshape(specs, (-1, npixel))[indice_sort]
                         err_series = np.reshape(errs, (-1, npixel))[indice_sort]
@@ -1986,7 +1987,7 @@ class CriresPipeline:
                         spec_series[:, -Ncut:] = np.nan
                         snr_mid = np.nanmean((spec_series/err_series)[wlens.shape[0]//2])
 
-                    else:
+                    else:  # data_frame
                         # reshape spectra in 3D shape: (N_frames, N_chips, N_pixel)
                         spec_series, err_series = [], []
                         specs, errs = np.array(specs), np.array(errs)
@@ -2006,7 +2007,7 @@ class CriresPipeline:
                                         header=hdr)
                     self._add_to_product('/'.join(file_name.split('/')[-2:])+'.fits', 
                                     '_'.join(['SPEC']+label.split('_')[-2:]))
-                    if data_type == data_comb:
+                    if j == 1:  # data_comb
                         np.savetxt(file_name+'.dat', np.c_[wlens.flatten(), 
                                                             spec_series.flatten(), 
                                                             err_series.flatten()], 


### PR DESCRIPTION
fix small edge-case bug in `refine_wlen_solution` where excalibuhr would illegally take the truth value of an array when performing operations on multiple frames. i noticed this error when using the `obs_extract` recipe and have since been able to run the recipe on spatially resolved companions without issue.